### PR TITLE
adjust mango dtb file name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,8 @@ jobs:
                   cp $RV_OUTPUT_DIR/zsbl.bin ~/efi/
                   cp $GITHUB_WORKSPACE/bootloader-riscv/firmware/fip.bin ~/efi/
                   cp $RV_OUTPUT_DIR/riscv64_Image ~/efi/riscv64
-                  cp $RV_OUTPUT_DIR/mango_evb_v0.1.dtb ~/efi/riscv64
+                  cp $RV_OUTPUT_DIR/mango-sophgo-x8evb.dtb ~/efi/riscv64
+                  cp $RV_OUTPUT_DIR/mango-milkv-pioneer.dtb ~/efi/riscv64
                   cp $RV_OUTPUT_DIR/initrd.img ~/efi/riscv64
                   cp $RV_OUTPUT_DIR/fw_jump.bin ~/efi/riscv64
 

--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -578,7 +578,8 @@ EOT
 
 	sudo cp $RV_OUTPUT_DIR/zsbl.bin $RV_OUTPUT_DIR/ext4/boot/efi/
 	sudo cp $RV_OUTPUT_DIR/riscv64_Image $RV_OUTPUT_DIR/ext4/boot/efi/riscv64
-	sudo cp $RV_OUTPUT_DIR/mango_evb_v0.1.dtb $RV_OUTPUT_DIR/ext4/boot/efi/riscv64
+	sudo cp $RV_OUTPUT_DIR/mango-sophgo-x8evb.dtb $RV_OUTPUT_DIR/ext4/boot/efi/riscv64
+	sudo cp $RV_OUTPUT_DIR/mango-milkv-pioneer.dtb $RV_OUTPUT_DIR/ext4/boot/efi/riscv64
 	sudo cp $RV_OUTPUT_DIR/initrd.img $RV_OUTPUT_DIR/ext4/boot/efi/riscv64
 	sudo cp $RV_OUTPUT_DIR/fw_jump.bin $RV_OUTPUT_DIR/ext4/boot/efi/riscv64
 	sudo touch $RV_OUTPUT_DIR/ext4/boot/efi/BOOT

--- a/zsbl/plat/sg2042/boot.c
+++ b/zsbl/plat/sg2042/boot.c
@@ -23,7 +23,7 @@
 #include <libfdt.h>
 //#include <thread_safe_printf.h>
 
-#define FILE_NUM	5
+#define FILE_NUM	6
 //#define ZSBL_BOOT_DEBUG
 //#define ZSBL_BOOT_DEBUG_LOOP
 
@@ -116,7 +116,8 @@ char *sd_img_name[FILE_NUM] = {
 	"0:riscv64/riscv64_Image",
 	"0:riscv64/initrd.img",
 	"0:riscv64/mango.dtb",
-	"0:riscv64/mango_evb_v0.1.dtb",
+	"0:riscv64/mango-sophgo-x8evb.dtb",
+	"0:riscv64/mango-milkv-pioneer.dtb",
 };
 
 char *spflash_img_name[FILE_NUM] = {
@@ -124,7 +125,8 @@ char *spflash_img_name[FILE_NUM] = {
 	"riscv64_Image",
 	"initrd.img",
 	"mango.dtb",
-	"mango_evb_v0.1.dtb",
+	"mango-sophgo-x8evb.dtb",
+	"mango-milkv-pioneer.dtb",
 };
 
 char *ddr_node_name[SG2042_MAX_CHIP_NUM][DDR_CHANLE_NUM] = {
@@ -203,12 +205,16 @@ int build_bootfile_info(int dev_num)
 			boot_file[i].name = sd_img_name[i];
 		if (mmio_read_32(BOARD_TYPE_REG) == 0x02)
 			boot_file[3].name = sd_img_name[4];
+		else if (mmio_read_32(BOARD_TYPE_REG) == 0x03)
+			boot_file[3].name = sd_img_name[5];
 	}
 	else if (dev_num == IO_DEVICE_SPIFLASH) {
 		for (int i = 0; i < ID_MAX; i++)
 			boot_file[i].name = spflash_img_name[i];
 		if (mmio_read_32(BOARD_TYPE_REG) == 0x02)
 			boot_file[3].name = spflash_img_name[4];
+		else if (mmio_read_32(BOARD_TYPE_REG) == 0x03)
+			boot_file[3].name = spflash_img_name[5];
 	}
 	else
 		return -1;


### PR DESCRIPTION
1. add mango-milkv-pioneer.dtb to support milkV Pioneer EVB
2. modify scripts to support new name: mango-sophgo-x8evb.dtb