### PR TITLE
zsbl: plat: sg2042: detect board type dynamically

### DIFF
--- a/zsbl/plat/sg2042/Makefile
+++ b/zsbl/plat/sg2042/Makefile
@@ -1,3 +1,4 @@
 obj-y += plat.o
 obj-y += boot.o
+obj-y += ini.o
 ccflags-y += -Iplat/sg2042_a53/include -Ilib/fat32/source

--- a/zsbl/plat/sg2042/include/ini.h
+++ b/zsbl/plat/sg2042/include/ini.h
@@ -1,0 +1,178 @@
+/* inih -- simple .INI file parser
+
+SPDX-License-Identifier: BSD-3-Clause
+
+Copyright (C) 2009-2020, Ben Hoyt
+
+inih is released under the New BSD license (see LICENSE.txt). Go to the project
+home page for more info:
+
+https://github.com/benhoyt/inih
+
+*/
+
+#ifndef INI_H
+#define INI_H
+
+/* Make this header file easier to include in C++ code */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+
+/* Nonzero if ini_handler callback should accept lineno parameter. */
+#ifndef INI_HANDLER_LINENO
+#define INI_HANDLER_LINENO 0
+#endif
+
+/* Visibility symbols, required for Windows DLLs */
+#ifndef INI_API
+#if defined _WIN32 || defined __CYGWIN__
+#	ifdef INI_SHARED_LIB
+#		ifdef INI_SHARED_LIB_BUILDING
+#			define INI_API __declspec(dllexport)
+#		else
+#			define INI_API __declspec(dllimport)
+#		endif
+#	else
+#		define INI_API
+#	endif
+#else
+#	if defined(__GNUC__) && __GNUC__ >= 4
+#		define INI_API __attribute__ ((visibility ("default")))
+#	else
+#		define INI_API
+#	endif
+#endif
+#endif
+
+/* Typedef for prototype of handler function. */
+#if INI_HANDLER_LINENO
+typedef int (*ini_handler)(void* user, const char* section,
+                           const char* name, const char* value,
+                           int lineno);
+#else
+typedef int (*ini_handler)(void* user, const char* section,
+                           const char* name, const char* value);
+#endif
+
+/* Typedef for prototype of fgets-style reader function. */
+typedef char* (*ini_reader)(char* str, int num, void* stream);
+
+/* Parse given INI-style file. May have [section]s, name=value pairs
+   (whitespace stripped), and comments starting with ';' (semicolon). Section
+   is "" if name=value pair parsed before any section heading. name:value
+   pairs are also supported as a concession to Python's configparser.
+
+   For each name=value pair parsed, call handler function with given user
+   pointer as well as section, name, and value (data only valid for duration
+   of handler call). Handler should return nonzero on success, zero on error.
+
+   Returns 0 on success, line number of first error on parse error (doesn't
+   stop on first error), -1 on file open error, or -2 on memory allocation
+   error (only when INI_USE_STACK is zero).
+*/
+INI_API int ini_parse(const char* filename, ini_handler handler, void* user);
+
+/* Same as ini_parse(), but takes a FILE* instead of filename. This doesn't
+   close the file when it's finished -- the caller must do that. */
+INI_API int ini_parse_file(FILE* file, ini_handler handler, void* user);
+
+/* Same as ini_parse(), but takes an ini_reader function pointer instead of
+   filename. Used for implementing custom or string-based I/O (see also
+   ini_parse_string). */
+INI_API int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
+                     void* user);
+
+/* Same as ini_parse(), but takes a zero-terminated string with the INI data
+instead of a file. Useful for parsing INI data from a network socket or
+already in memory. */
+INI_API int ini_parse_string(const char* string, ini_handler handler, void* user);
+
+/* Nonzero to allow multi-line value parsing, in the style of Python's
+   configparser. If allowed, ini_parse() will call the handler with the same
+   name for each subsequent line parsed. */
+#ifndef INI_ALLOW_MULTILINE
+#define INI_ALLOW_MULTILINE 1
+#endif
+
+/* Nonzero to allow a UTF-8 BOM sequence (0xEF 0xBB 0xBF) at the start of
+   the file. See https://github.com/benhoyt/inih/issues/21 */
+#ifndef INI_ALLOW_BOM
+#define INI_ALLOW_BOM 1
+#endif
+
+/* Chars that begin a start-of-line comment. Per Python configparser, allow
+   both ; and # comments at the start of a line by default. */
+#ifndef INI_START_COMMENT_PREFIXES
+#define INI_START_COMMENT_PREFIXES ";#"
+#endif
+
+/* Nonzero to allow inline comments (with valid inline comment characters
+   specified by INI_INLINE_COMMENT_PREFIXES). Set to 0 to turn off and match
+   Python 3.2+ configparser behaviour. */
+#ifndef INI_ALLOW_INLINE_COMMENTS
+#define INI_ALLOW_INLINE_COMMENTS 1
+#endif
+#ifndef INI_INLINE_COMMENT_PREFIXES
+#define INI_INLINE_COMMENT_PREFIXES ";"
+#endif
+
+/* Nonzero to use stack for line buffer, zero to use heap (malloc/free). */
+#ifndef INI_USE_STACK
+#define INI_USE_STACK 1
+#endif
+
+/* Maximum line length for any line in INI file (stack or heap). Note that
+   this must be 3 more than the longest line (due to '\r', '\n', and '\0'). */
+#ifndef INI_MAX_LINE
+#define INI_MAX_LINE 200
+#endif
+
+/* Nonzero to allow heap line buffer to grow via realloc(), zero for a
+   fixed-size buffer of INI_MAX_LINE bytes. Only applies if INI_USE_STACK is
+   zero. */
+#ifndef INI_ALLOW_REALLOC
+#define INI_ALLOW_REALLOC 0
+#endif
+
+/* Initial size in bytes for heap line buffer. Only applies if INI_USE_STACK
+   is zero. */
+#ifndef INI_INITIAL_ALLOC
+#define INI_INITIAL_ALLOC 200
+#endif
+
+/* Stop parsing on first error (default is to keep parsing). */
+#ifndef INI_STOP_ON_FIRST_ERROR
+#define INI_STOP_ON_FIRST_ERROR 0
+#endif
+
+/* Nonzero to call the handler at the start of each new section (with
+   name and value NULL). Default is to only call the handler on
+   each name=value pair. */
+#ifndef INI_CALL_HANDLER_ON_NEW_SECTION
+#define INI_CALL_HANDLER_ON_NEW_SECTION 0
+#endif
+
+/* Nonzero to allow a name without a value (no '=' or ':' on the line) and
+   call the handler with value NULL in this case. Default is to treat
+   no-value lines as an error. */
+#ifndef INI_ALLOW_NO_VALUE
+#define INI_ALLOW_NO_VALUE 0
+#endif
+
+/* Nonzero to use custom ini_malloc, ini_free, and ini_realloc memory
+   allocation functions (INI_USE_STACK must also be 0). These functions must
+   have the same signatures as malloc/free/realloc and behave in a similar
+   way. ini_realloc is only needed if INI_ALLOW_REALLOC is set. */
+#ifndef INI_CUSTOM_ALLOCATOR
+#define INI_CUSTOM_ALLOCATOR 0
+#endif
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INI_H */

--- a/zsbl/plat/sg2042/ini.c
+++ b/zsbl/plat/sg2042/ini.c
@@ -1,0 +1,304 @@
+/* inih -- simple .INI file parser
+
+SPDX-License-Identifier: BSD-3-Clause
+
+Copyright (C) 2009-2020, Ben Hoyt
+
+inih is released under the New BSD license (see LICENSE.txt). Go to the project
+home page for more info:
+
+https://github.com/benhoyt/inih
+
+*/
+
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+
+#include "ini.h"
+
+#if !INI_USE_STACK
+#if INI_CUSTOM_ALLOCATOR
+#include <stddef.h>
+void* ini_malloc(size_t size);
+void ini_free(void* ptr);
+void* ini_realloc(void* ptr, size_t size);
+#else
+#include <stdlib.h>
+#define ini_malloc malloc
+#define ini_free free
+#define ini_realloc realloc
+#endif
+#endif
+
+#define MAX_SECTION 50
+#define MAX_NAME 50
+
+/* Used by ini_parse_string() to keep track of string parsing state. */
+typedef struct {
+	const char* ptr;
+	size_t num_left;
+} ini_parse_string_ctx;
+
+/* Strip whitespace chars off end of given string, in place. Return s. */
+static char* rstrip(char* s)
+{
+	char* p = s + strlen(s);
+	while (p > s && isspace((unsigned char)(*--p)))
+		*p = '\0';
+	return s;
+}
+
+/* Return pointer to first non-whitespace char in given string. */
+static char* lskip(const char* s)
+{
+	while (*s && isspace((unsigned char)(*s)))
+		s++;
+	return (char*)s;
+}
+
+/* Return pointer to first char (of chars) or inline comment in given string,
+   or pointer to NUL at end of string if neither found. Inline comment must
+   be prefixed by a whitespace character to register as a comment. */
+static char* find_chars_or_comment(const char* s, const char* chars)
+{
+#if INI_ALLOW_INLINE_COMMENTS
+	int was_space = 0;
+	while (*s && (!chars || !strchr(chars, *s)) &&
+			!(was_space && strchr(INI_INLINE_COMMENT_PREFIXES, *s))) {
+		was_space = isspace((unsigned char)(*s));
+		s++;
+	}
+#else
+	while (*s && (!chars || !strchr(chars, *s))) {
+		s++;
+	}
+#endif
+	return (char*)s;
+}
+
+/* Similar to strncpy, but ensures dest (size bytes) is
+   NUL-terminated, and doesn't pad with NULs. */
+static char* strncpy0(char* dest, const char* src, size_t size)
+{
+	/* Could use strncpy internally, but it causes gcc warnings (see issue #91) */
+	size_t i;
+	for (i = 0; i < size - 1 && src[i]; i++)
+		dest[i] = src[i];
+	dest[i] = '\0';
+	return dest;
+}
+
+/* See documentation in header file. */
+int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
+				     void* user)
+{
+	/* Uses a fair bit of stack (use heap instead if you need to) */
+#if INI_USE_STACK
+	char line[INI_MAX_LINE];
+	size_t max_line = INI_MAX_LINE;
+#else
+	char* line;
+	size_t max_line = INI_INITIAL_ALLOC;
+#endif
+#if INI_ALLOW_REALLOC && !INI_USE_STACK
+	char* new_line;
+	size_t offset;
+#endif
+	char section[MAX_SECTION] = "";
+	char prev_name[MAX_NAME] = "";
+
+	char* start;
+	char* end;
+	char* name;
+	char* value;
+	int lineno = 0;
+	int error = 0;
+
+#if !INI_USE_STACK
+	line = (char*)ini_malloc(INI_INITIAL_ALLOC);
+	if (!line) {
+		return -2;
+	}
+#endif
+
+#if INI_HANDLER_LINENO
+#define HANDLER(u, s, n, v) handler(u, s, n, v, lineno)
+#else
+#define HANDLER(u, s, n, v) handler(u, s, n, v)
+#endif
+
+	/* Scan through stream line by line */
+	while (reader(line, (int)max_line, stream) != NULL) {
+#if INI_ALLOW_REALLOC && !INI_USE_STACK
+		offset = strlen(line);
+		while (offset == max_line - 1 && line[offset - 1] != '\n') {
+			max_line *= 2;
+			if (max_line > INI_MAX_LINE)
+				max_line = INI_MAX_LINE;
+			new_line = ini_realloc(line, max_line);
+			if (!new_line) {
+				ini_free(line);
+				return -2;
+			}
+			line = new_line;
+			if (reader(line + offset, (int)(max_line - offset), stream) == NULL)
+				break;
+			if (max_line >= INI_MAX_LINE)
+				break;
+			offset += strlen(line + offset);
+		}
+#endif
+
+		lineno++;
+
+		start = line;
+#if INI_ALLOW_BOM
+		if (lineno == 1 && (unsigned char)start[0] == 0xEF &&
+						   (unsigned char)start[1] == 0xBB &&
+						   (unsigned char)start[2] == 0xBF) {
+			start += 3;
+		}
+#endif
+		start = lskip(rstrip(start));
+
+		if (strchr(INI_START_COMMENT_PREFIXES, *start)) {
+			/* Start-of-line comment */
+		}
+#if INI_ALLOW_MULTILINE
+		else if (*prev_name && *start && start > line) {
+#if INI_ALLOW_INLINE_COMMENTS
+			end = find_chars_or_comment(start, NULL);
+			if (*end)
+				*end = '\0';
+			rstrip(start);
+#endif
+			/* Non-blank line with leading whitespace, treat as continuation
+			   of previous name's value (as per Python configparser). */
+			if (!HANDLER(user, section, prev_name, start) && !error)
+				error = lineno;
+		}
+#endif
+		else if (*start == '[') {
+			/* A "[section]" line */
+			end = find_chars_or_comment(start + 1, "]");
+			if (*end == ']') {
+				*end = '\0';
+				strncpy0(section, start + 1, sizeof(section));
+				*prev_name = '\0';
+#if INI_CALL_HANDLER_ON_NEW_SECTION
+				if (!HANDLER(user, section, NULL, NULL) && !error)
+					error = lineno;
+#endif
+			}
+			else if (!error) {
+				/* No ']' found on section line */
+				error = lineno;
+			}
+		}
+		else if (*start) {
+			/* Not a comment, must be a name[=:]value pair */
+			end = find_chars_or_comment(start, "=:");
+			if (*end == '=' || *end == ':') {
+				*end = '\0';
+				name = rstrip(start);
+				value = end + 1;
+#if INI_ALLOW_INLINE_COMMENTS
+				end = find_chars_or_comment(value, NULL);
+				if (*end)
+					*end = '\0';
+#endif
+				value = lskip(value);
+				rstrip(value);
+
+				/* Valid name[=:]value pair found, call handler */
+				strncpy0(prev_name, name, sizeof(prev_name));
+				if (!HANDLER(user, section, name, value) && !error)
+					error = lineno;
+			}
+			else if (!error) {
+				/* No '=' or ':' found on name[=:]value line */
+#if INI_ALLOW_NO_VALUE
+				*end = '\0';
+				name = rstrip(start);
+				if (!HANDLER(user, section, name, NULL) && !error)
+					error = lineno;
+#else
+				error = lineno;
+#endif
+			}
+		}
+
+#if INI_STOP_ON_FIRST_ERROR
+		if (error)
+			break;
+#endif
+	}
+
+#if !INI_USE_STACK
+	ini_free(line);
+#endif
+
+	return error;
+}
+
+/* See documentation in header file. */
+int ini_parse_file(FILE* file, ini_handler handler, void* user)
+{
+	return ini_parse_stream((ini_reader)fgets, file, handler, user);
+}
+
+/* See documentation in header file. */
+int ini_parse(const char* filename, ini_handler handler, void* user)
+{
+	FILE* file;
+	int error;
+
+	file = fopen(filename, "r");
+	if (!file)
+		return -1;
+	error = ini_parse_file(file, handler, user);
+	fclose(file);
+	return error;
+}
+
+/* An ini_reader function to read the next line from a string buffer. This
+   is the fgets() equivalent used by ini_parse_string(). */
+static char* ini_reader_string(char* str, int num, void* stream) {
+	ini_parse_string_ctx* ctx = (ini_parse_string_ctx*)stream;
+	const char* ctx_ptr = ctx->ptr;
+	size_t ctx_num_left = ctx->num_left;
+	char* strp = str;
+	char c;
+
+	if (ctx_num_left == 0 || num < 2)
+		return NULL;
+
+	while (num > 1 && ctx_num_left != 0) {
+		c = *ctx_ptr++;
+		ctx_num_left--;
+		*strp++ = c;
+		if (c == '\n')
+			break;
+		num--;
+	}
+
+	*strp = '\0';
+	ctx->ptr = ctx_ptr;
+	ctx->num_left = ctx_num_left;
+	return str;
+}
+
+/* See documentation in header file. */
+int ini_parse_string(const char* string, ini_handler handler, void* user) {
+	ini_parse_string_ctx ctx;
+
+	ctx.ptr = string;
+	ctx.num_left = strlen(string);
+	return ini_parse_stream((ini_reader)ini_reader_string, &ctx, handler,
+						    user);
+}


### PR DESCRIPTION
The conf.ini contains board configuration information. The convention is that the conf.ini must start at byte 0 with a section called sophgo-config, without any comments. In addition, the current conf.ini contains the [devicetree] section, which has two keys, namely name and addr.

The conf.ini is saved in SPI Flash1 and will be added to EEPROM in the future.