### PR TITLE
Fix: support case that dtb name is not in conf.ini

### DIFF
--- a/zsbl/plat/sg2042/boot.c
+++ b/zsbl/plat/sg2042/boot.c
@@ -224,7 +224,8 @@ static int mango_parse_ini(void)
 	if (strncmp(header, read_buf, strlen(header)))
 		return -1;
 
-	if (ini_parse_string((const char*)read_buf, handler, &config) < 0)
+	if (ini_parse_string((const char*)read_buf, handler, &config) < 0
+		|| config.name == NULL)
 		return -1;
 
 	return 0;


### PR DESCRIPTION
When the conf.ini does not contain dtb info, still enter the original branch to get dtb name.