### PR TITLE
fix bug of scripts/envsetup.sh

### DIFF
--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -93,7 +93,7 @@ RV_LINUX_GCC_INSTALL_DIR=$RV_GCC_DIR/gcc-riscv64-unknown-linux-gnu
 # riscv specific variables
 HOST_ARCH=`uname -m`
 
-if [ $HOST_ARCH == 'riscv64' ]; then
+if [ $HOST_ARCH = 'riscv64' ]; then
 	RISCV64_LINUX_CROSS_COMPILE=
 else
 	RISCV64_LINUX_CROSS_COMPILE=$RV_LINUX_GCC_INSTALL_DIR/bin/riscv64-unknown-linux-gnu-


### PR DESCRIPTION
An error is reported when executing the following shell
Shell: source scripts/envsetup.sh
Error: scripts/envsetup.sh:96: = not found