### PR TITLE
scripts:Add parameters in fedora kernel command line

### DIFF
--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -1062,7 +1062,7 @@ label fedora_sophgo
 	menu label Fedora Sophgo in SD
 	linux /vmlinuz-$kernel_version
 	initrd /initramfs-$kernel_version.img
-	append  console=ttyS0,115200 root=LABEL=ROOT rootfstype=ext4 rootwait rw earlycon selinux=0 LANG=en_US.UTF-8
+	append  console=ttyS0,115200 root=LABEL=ROOT rootfstype=ext4 rootwait rw earlycon selinux=0 LANG=en_US.UTF-8 nvme_core.io_timeout=600 nvme_core.admin_timeout=600 cma=512M swiotlb=65536
 EOF
 
 umount /boot


### PR DESCRIPTION
1.Expand the tolerable time of nvme io transmission and management timeout to 600s.
2.Expand contiguous memory allocator from 16M to 512M 
3.Expand swiotlb from 64M to 128M
The purpose is to fix ext4fs error bug.