### PR TITLE
scripts: remove "quiet splash" from grub.cfg

### DIFF
--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -1170,7 +1170,7 @@ set timeout=2
 set term="vt100"
 
 menuentry 'Ubuntu on SG2042' {
-    linux /boot/vmlinuz-$kernel_version  console=ttyS0,115200 root=LABEL=cloudimg-rootfs rootfstype=ext4 quiet splash rootwait rw earlycon selinux=0 LANG=en_US.UTF-8
+    linux /boot/vmlinuz-$kernel_version  console=ttyS0,115200 root=LABEL=cloudimg-rootfs rootfstype=ext4 rootwait rw earlycon selinux=0 LANG=en_US.UTF-8
     initrd /boot/initrd.img-$kernel_version
 }
 
@@ -1444,7 +1444,7 @@ set timeout=2
 set term="vt100"
 
 menuentry 'Fedora 38 on SG2042' {
-    linux /vmlinuz-$kernel_version  console=ttyS0,115200 root=LABEL=ROOT rootfstype=ext4 quiet splash rootwait rw earlycon selinux=0 LANG=en_US.UTF-8 nvme_core.io_timeout=600 nvme_core.admin_timeout=600 cma=512M swiotlb=65536
+    linux /vmlinuz-$kernel_version  console=ttyS0,115200 root=LABEL=ROOT rootfstype=ext4 rootwait rw earlycon selinux=0 LANG=en_US.UTF-8 nvme_core.io_timeout=600 nvme_core.admin_timeout=600 cma=512M swiotlb=65536
     initrd /initramfs-$kernel_version.img
 }
 


### PR DESCRIPTION
Remove "quiet" to show the boot log for debugging; "splash" causes the BMC RTC to work badly because "splash" will use the framebuffer by the BMC's BAR to load and store the pixel.