### PR TITLE
scripts: Parallelize building GNU toolchain

### DIFF
--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -231,7 +231,7 @@ function build_rv_linux_gcc()
 	make clean
 	git checkout 2023.11.08
 	./configure --prefix=$RV_LINUX_GCC_INSTALL_DIR
-	make linux
+	make linux -j$(nproc)
 	popd
 	popd
 }
@@ -249,7 +249,7 @@ function build_rv_elf_gcc()
 	make clean
 	git checkout 2023.11.08
 	./configure --with-cmodel=medany --with-arch=rv64imafdc --with-abi=lp64d --prefix=$RV_ELF_GCC_INSTALL_DIR
-	make
+	make -j$(nproc)
 	popd
 	popd
 }


### PR DESCRIPTION
Building the riscv-gnu-toolchain is not parallelized, leading to relatively slow build times. This commit uses the `make -j$(nproc)` convention to parallelize building GCC and friends, as is done elsewhere in the script. For my machine, build time improves from 87 minutes to 15.

Resolves: #84