### PR TITLE
sg2044: fix compile warning when build_rv_ubuntu_image.

### DIFF
--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -1217,7 +1217,7 @@ function build_rv_ubuntu_image()
 	sudo resize2fs /dev/mapper/$root_part
 
 	echo mount root partition...
-	mkdir $RV_OUTPUT_DIR/root
+	mkdir -p $RV_OUTPUT_DIR/root
 	sudo mount /dev/mapper/$root_part $RV_OUTPUT_DIR/root
 
 	sudo mount --bind /proc $RV_OUTPUT_DIR/root/proc
@@ -1274,8 +1274,8 @@ EOT
 	sudo umount $RV_OUTPUT_DIR/root/sys
 	sudo umount $RV_OUTPUT_DIR/root/dev/pts
 	sudo umount $RV_OUTPUT_DIR/root/dev
-	sudo umount /dev/mapper/$efi_part
-	sudo umount /dev/mapper/$root_part
+	sudo umount $RV_OUTPUT_DIR/efi
+	sudo umount $RV_OUTPUT_DIR/root
 	sudo kpartx -d $RV_OUTPUT_DIR/$RV_UBUNTU_SOPHGO_IMAGE
 	sudo kpartx -d $RV_DISTRO_DIR/$RV_UBUNTU_DISTRO/$RV_UBUNTU_OFFICIAL_IMAGE
 	sudo rm -r $RV_OUTPUT_DIR/efi


### PR DESCRIPTION
1. mkdir use -p parameters to avoid mkdir return error when the directory is already exists.
2. umount use directory parameters to avoid umount dev can only remove one dev node, if there are multi dev mount to this dir, only umount one dev will not remove all dev node on this dir.