### PR TITLE
bm1690: set rp_Image name also to riscv64_Image for Soc mode.

### DIFF
--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -1247,6 +1247,9 @@ function build_rv_ubuntu_image()
 
 	sudo cp $RV_FIRMWARE_INSTALL_DIR/fw_dynamic.bin $RV_OUTPUT_DIR/efi/riscv64
 	sudo cp $RV_FIRMWARE_INSTALL_DIR/*_Image $RV_OUTPUT_DIR/efi/riscv64
+	if [ "$CHIP" = "bm1690" ]; then
+		sudo cp $RV_OUTPUT_DIR/efi/riscv64/rp_Image $RV_OUTPUT_DIR/efi/riscv64/riscv64_Image
+	fi
 	sudo cp $RV_FIRMWARE_INSTALL_DIR/*.dtb $RV_OUTPUT_DIR/efi/riscv64
 
 	echo copy ubuntu...

--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -1247,7 +1247,7 @@ function build_rv_ubuntu_image()
 
 	sudo cp $RV_FIRMWARE_INSTALL_DIR/fw_dynamic.bin $RV_OUTPUT_DIR/efi/riscv64
 	if [ "$CHIP" = "bm1690" ]; then
-		sudo cp $RV_OUTPUT_DIR/efi/riscv64/rp_Image $RV_OUTPUT_DIR/efi/riscv64/riscv64_Image
+		sudo cp $RV_FIRMWARE_INSTALL_DIR/rp_Image $RV_OUTPUT_DIR/efi/riscv64/riscv64_Image
 	else
 		sudo cp $RV_FIRMWARE_INSTALL_DIR/riscv64_Image $RV_OUTPUT_DIR/efi/riscv64
 	fi

--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -1246,9 +1246,10 @@ function build_rv_ubuntu_image()
 	fi
 
 	sudo cp $RV_FIRMWARE_INSTALL_DIR/fw_dynamic.bin $RV_OUTPUT_DIR/efi/riscv64
-	sudo cp $RV_FIRMWARE_INSTALL_DIR/*_Image $RV_OUTPUT_DIR/efi/riscv64
 	if [ "$CHIP" = "bm1690" ]; then
 		sudo cp $RV_OUTPUT_DIR/efi/riscv64/rp_Image $RV_OUTPUT_DIR/efi/riscv64/riscv64_Image
+	else
+		sudo cp $RV_FIRMWARE_INSTALL_DIR/riscv64_Image $RV_OUTPUT_DIR/efi/riscv64
 	fi
 	sudo cp $RV_FIRMWARE_INSTALL_DIR/*.dtb $RV_OUTPUT_DIR/efi/riscv64
 


### PR DESCRIPTION
rp_Image and riscv64_Image is the same file. rp_Image is used for PCIe mode, riscv64_Image is used for first stage linux for rp in Soc mode.