### PR TITLE
Fix incorrect use of [ || ]

### DIFF
--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -1495,7 +1495,7 @@ function build_rv_fedora_image()
 	sudo mkdir -p $RV_OUTPUT_DIR/efi/EFI/BOOT
 	sudo mkdir -p $RV_OUTPUT_DIR/efi/EFI/fedora
 
-	if [ "$CHIP" = "sg2044" || "$CHIP" = "bm1690" ];then
+	if [[ "$CHIP" = "sg2044" || "$CHIP" = "bm1690" ]];then
 	sudo cp $RV_FIRMWARE/fsbl.bin $RV_OUTPUT_DIR/efi/riscv64
 	sudo cp $RV_FIRMWARE_INSTALL_DIR/zsbl.bin $RV_OUTPUT_DIR/efi/riscv64
 	else
@@ -1781,7 +1781,7 @@ function build_rv_firmware_image()
 	sudo mkdir -p efi/riscv64
 
 	echo copy bootloader...
-	if [ "$CHIP" = "sg2044" || "$CHIP" = "bm1690" ];then
+	if [[ "$CHIP" = "sg2044" || "$CHIP" = "bm1690" ]];then
 	sudo cp $RV_FIRMWARE/fsbl.bin efi/riscv64
 	sudo cp zsbl.bin efi/riscv64
 	else
@@ -1824,7 +1824,7 @@ function build_rv_firmware_package()
 	mkdir -p firmware/riscv64
 
 	echo copy bootloader...
-	if [ "$CHIP" = "sg2044" || "$CHIP" = "bm1690" ];then
+	if [[ "$CHIP" = "sg2044" || "$CHIP" = "bm1690" ]];then
 	cp $RV_FIRMWARE/fsbl.bin firmware/riscv64
 	cp zsbl.bin firmware/riscv64
 	else


### PR DESCRIPTION
To use || for OR test, [[ ]] should be used instead of [].

This fixes below error:
  scripts/envsetup.sh: line 1784: [: missing `]'
  scripts/envsetup.sh: line 1784: mango: command not found