### PR TITLE
script: fix flash-kernel error after install image.

### DIFF
--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -1362,6 +1362,8 @@ apt purge -y linux-image-6.8.0*
 apt purge -y linux-headers-6.8.0*
 dpkg -i /home/ubuntu/bsp-debs/linux-image-*[0-9].deb
 apt autoremove -y
+rm -rf /etc/initramfs/post-update.d/flash-kernel
+rm -rf /etc/kernel/postinst.d/zz-flash-kernel
 apt-mark hold linux-image-6.5.5
 cat > /etc/modprobe.d/sg2042-blacklist.conf << EOF
 blacklist switchtec


### PR DESCRIPTION
If we install linux-image-6.5.5.deb in Ubuntu24.04, then run apt update, will cause flash-kernel error. So delete this file that we don't use to avoid this error.