### PR TITLE
scripts: modify TARGET to DBEUG of EDK II

### DIFF
--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -500,8 +500,8 @@ function build_rv_edk2()
 		git checkout devel-${CHIP}
 		popd
 
-		TARGET=RELEASE
-		build -a RISCV64 -t GCC5 -b $TARGET -D X64EMU_ENABLE -p Platform/Sophgo/${CHIP^^}Pkg/${CHIP^^}.dsc
+		TARGET=DEBUG
+		build -a RISCV64 -t GCC5 -b $TARGET -p Platform/Sophgo/${CHIP^^}Pkg/${CHIP^^}.dsc
 
 		mkdir -p $RV_FIRMWARE_INSTALL_DIR
 


### PR DESCRIPTION
In the development phase, modify compilation TARGET to DEBUG from RELEASE to show more debug information when running EDK II.