### PR TITLE
scripts:gen_sg2042_image:avoid returning non-zero value on exit

### DIFF
--- a/scripts/gen_sg2042_img.sh
+++ b/scripts/gen_sg2042_img.sh
@@ -136,7 +136,7 @@ EOF
 
 #enable powergood service in host to adapt BMC wdt function
 echo enable powergood service
-[ -e /etc/systemd/system/powergood.service ] && systemctl enable powergood.service
+if [ -e /etc/systemd/system/powergood.service ]; then systemctl enable powergood.service; fi
 
 exit
 EOT
@@ -274,7 +274,7 @@ EOF
 
 #enable powergood service in host to adapt BMC wdt function
 echo enable powergood service
-[ -e /etc/systemd/system/powergood.service ] && systemctl enable powergood.service
+if [ -e /etc/systemd/system/powergood.service ]; then systemctl enable powergood.service; fi
 
 exit
 
@@ -457,7 +457,7 @@ EOF
 
 #enable powergood service in host to adapt BMC wdt function
 echo enable powergood service
-[ -e /etc/systemd/system/powergood.service ] && systemctl enable powergood.service
+if [ -e /etc/systemd/system/powergood.service ]; then systemctl enable powergood.service; fi
 
 exit
 EOT


### PR DESCRIPTION
When CHIP_NUM=single, [ -e /etc/systemd/system/powergood.service] return 1, this will be considered as a compilation problem and exit directly because the building environment has executed 'set -e'.