### PR TITLE
sctipt:sg2042::remove single `popd`

### DIFF
--- a/scripts/gen_sg2042_img.sh
+++ b/scripts/gen_sg2042_img.sh
@@ -279,7 +279,6 @@ if [ -e /etc/systemd/system/powergood.service ]; then systemctl enable powergood
 exit
 
 EOT
-	popd
 
 	echo cleanup...
 	sync


### PR DESCRIPTION
In function build_rv_euler_image, there is only a `popd` without `pushd`, which caused "directory stack empty" error