### PR TITLE
scripts: revert build_rv_pcie_zsbl for BM1690.

### DIFF
--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -313,14 +313,36 @@ function clean_rv_bootrom()
 
 function build_rv_pcie_zsbl()
 {
-    build_rv_zsbl
+	local err
+
+	pushd $RV_ZSBL_SRC_DIR
+	make CROSS_COMPILE=$RISCV64_LINUX_CROSS_COMPILE O=$RV_ZSBL_BUILD_DIR ARCH=riscv bm1690_pcie_defconfig
+	err=$?
+	popd
+
+	if [ $err -ne 0 ]; then
+		echo "making pcie zsbl config failed"
+		return $err
+	    fi
+
+	pushd $RV_ZSBL_BUILD_DIR
+	make -j$(nproc) CROSS_COMPILE=$RISCV64_LINUX_CROSS_COMPILE ARCH=riscv
+	err=$?
+	popd
+
+	if [ $err -ne 0 ]; then
+		echo "making zsbl failed"
+		return $err
+	    fi
+
+	mkdir -p $RV_FIRMWARE_INSTALL_DIR
 	cp $RV_ZSBL_BUILD_DIR/zsbl.bin $RV_FIRMWARE_INSTALL_DIR/pcie_zsbl.bin
 }
 
 function clean_rv_pcie_zsbl()
 {
-    clean_rv_zsbl
 	rm -rf $RV_FIRMWARE_INSTALL_DIR/pcie_zsbl.bin
+	rm -rf $RV_ZSBL_BUILD_DIR
 }
 
 function build_rv_tp_zsbl()


### PR DESCRIPTION
Now we use PCIe zsbl config for BM1690 in sg2260-pld branch, so keep this cmd until BM1690 switch to zsbl master branch.