### PR TITLE
scripts: refine mango and sg2044 build scripts

### DIFF
--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -923,7 +923,16 @@ EOT
 		RPMBUILD_DIR=$RV_KERNEL_SRC_DIR/rpmbuild
 	fi
 
-	make -j$(nproc) ARCH=riscv CROSS_COMPILE=$RISCV64_LINUX_CROSS_COMPILE LOCALVERSION="" rpm-pkg dtbs
+	make -j$(nproc) ARCH=riscv CROSS_COMPILE=$RISCV64_LINUX_CROSS_COMPILE LOCALVERSION="" dtbs
+	if [ ! -d $RV_FIRMWARE_INSTALL_DIR ]; then
+		mkdir -p $RV_FIRMWARE_INSTALL_DIR
+	else
+		rm -f $RV_FIRMWARE_INSTALL_DIR/${CHIP}-*.dtb
+	fi
+
+	cp $RV_KERNEL_SRC_DIR/arch/riscv/boot/dts/sophgo/${CHIP}-*.dtb $RV_FIRMWARE_INSTALL_DIR
+
+	make -j$(nproc) ARCH=riscv CROSS_COMPILE=$RISCV64_LINUX_CROSS_COMPILE LOCALVERSION="" rpm-pkg
 	ret=$?
 	rm ~/.rpmmacros
 	if [ -e ~/.rpmmacros.orig ]; then
@@ -944,18 +953,8 @@ EOT
 		rm -f $RV_RPM_INSTALL_DIR/kernel-*.rpm
 	fi
 
-	if [ ! -d $RV_FIRMWARE_INSTALL_DIR ]; then
-		mkdir -p $RV_FIRMWARE_INSTALL_DIR
-	else
-		rm -f $RV_FIRMWARE_INSTALL_DIR/${CHIP}-*.dtb
-	fi
 
 	cp $RPMBUILD_DIR/RPMS/riscv64/*.rpm $RV_RPM_INSTALL_DIR/
-	if [[ ${KERNELRELEASE:0:4} == "6.1." ]]; then
-		cp $RPMBUILD_DIR/BUILD/kernel-${KERNELRELEASE}/arch/riscv/boot/dts/sophgo/${CHIP}-*.dtb $RV_FIRMWARE_INSTALL_DIR
-	else
-		cp $RV_KERNEL_SRC_DIR/arch/riscv/boot/dts/sophgo/${CHIP}-*.dtb $RV_FIRMWARE_INSTALL_DIR
-	fi
 	make ARCH=riscv CROSS_COMPILE=$RISCV64_LINUX_CROSS_COMPILE distclean
 	rm *.tar.gz
 	rm -rf $RPMBUILD_DIR

--- a/scripts/gen_sg2044_img.sh
+++ b/scripts/gen_sg2044_img.sh
@@ -8,6 +8,8 @@ RV_EULER_OFFICIAL_IMAGE=openEuler-24.03-riscv64-sg2044-20241025.template.img
 DOWNLOAD_RV_EULER_OFFICIAL_IMAGE="wget https://github.com/sophgo/bootloader-riscv/releases/download/sg2044-v0.1/openEuler-24.03-riscv64-sg2044-20241025.template.img.xz"
 UNCOMPRESS_RV_EULER_OFFICIAL_IMAGE="unxz $RV_EULER_OFFICIAL_IMAGE.xz"
 
+RV_SG2044_FSBL_BIN="https://github.com/sophgo/bootloader-riscv/releases/download/sg2044-v0.1/fsbl.bin"
+
 function get_distro_info()
 {
     DISTRO_NAME=`echo $1 | awk -F '-' '{print $1}'`
@@ -85,6 +87,12 @@ function build_rv_image()
 	local EFI_PARTITION_DIR=$RV_OUTPUT_DIR/root/boot/efi
 
 	sudo mkdir $EFI_PARTITION_DIR/riscv64
+
+	if [ "$CHIP" = "sg2044" ]; then
+		if [ ! -f "$RV_FIRMWARE_INSTALL_DIR/fsbl.bin" ]; then
+			wget -O "$RV_FIRMWARE_INSTALL_DIR/fsbl.bin" "$RV_SG2044_FSBL_BIN"
+		fi
+	fi
 
 	sudo cp -v $RV_FIRMWARE_INSTALL_DIR/fsbl.bin $EFI_PARTITION_DIR/riscv64
 


### PR DESCRIPTION
 - Moved the DTB copy earlier to avoid issues with kernel Makefile version or rpmbuild tool version inconsistencies.

 - FSBL source code is not publicly available; the daily build system updates the SG2044 binary at a fixed link and will automatically download it if missing locally.