### PR TITLE
toolchain: upgrade riscv-gcc from 13.2 to 15.1

### DIFF
--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -232,7 +232,7 @@ function build_rv_linux_gcc()
 	pushd riscv-gnu-toolchain
 	rm -rf $RV_LINU_GCC_INSTALL_DIR
 	make clean
-	git checkout 2023.11.08
+	git checkout 2025.06.13
 	./configure --prefix=$RV_LINUX_GCC_INSTALL_DIR
 	make linux -j$(nproc)
 	popd
@@ -250,7 +250,7 @@ function build_rv_elf_gcc()
 	pushd riscv-gnu-toolchain
 	rm -rf $RV_ELF_GCC_INSTALL_DIR
 	make clean
-	git checkout 2023.11.08
+	git checkout 2025.06.13
 	./configure --with-cmodel=medany --with-arch=rv64imafdc --with-abi=lp64d --prefix=$RV_ELF_GCC_INSTALL_DIR
 	make -j$(nproc)
 	popd


### PR DESCRIPTION
Update riscv-gnu-toolchain checkout point from
2023.11.08 to 2025.06.13.