### PR TITLE
riscv:config: disable ZONE_DMA32 and SWIOTLB for ap/tp.

### DIFF
--- a/scripts/ap_tp_kernel.patch
+++ b/scripts/ap_tp_kernel.patch
@@ -1,0 +1,20 @@
+diff --git a/arch/riscv/Kconfig b/arch/riscv/Kconfig
+index 0ef752d9731b..c234659daff5 100644
+--- a/arch/riscv/Kconfig
++++ b/arch/riscv/Kconfig
+@@ -208,7 +208,6 @@ config RISCV
+ 	select TRACE_IRQFLAGS_SUPPORT
+ 	select UACCESS_MEMCPY if !MMU
+ 	select USER_STACKTRACE_SUPPORT
+-	select ZONE_DMA32 if 64BIT
+ 
+ config RUSTC_SUPPORTS_RISCV
+ 	def_bool y
+@@ -409,7 +408,6 @@ config ARCH_RV64I
+ 	bool "RV64I"
+ 	select 64BIT
+ 	select ARCH_SUPPORTS_INT128 if CC_HAS_INT128
+-	select SWIOTLB if MMU
+ 
+ endchoice
+ 

--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -735,6 +735,11 @@ function build_rv_kernel()
 	fi
 
 	pushd $RV_KERNEL_SRC_DIR
+	if [ "$1" = "ap" -o "$1" = "tp" ]; then
+		echo "Disable ZONE_DMA32 and SWIOTLB for ap/tp kernel!"
+		cp arch/riscv/Kconfig arch/riscv/Kconfig.orig
+		patch -p1 < $RV_TOP_DIR/bootloader-riscv/scripts/ap_tp_kernel.patch
+	fi
 	make O=$RV_KERNEL_BUILD_DIR ARCH=riscv CROSS_COMPILE=$RISCV64_LINUX_CROSS_COMPILE $RV_KERNEL_CONFIG
 	err=$?
 	popd
@@ -752,7 +757,9 @@ function build_rv_kernel()
 	err=$?
 
 	popd
-
+	if [ "$1" = "ap" -o "$1" = "tp" ]; then
+		mv $RV_KERNEL_SRC_DIR/arch/riscv/Kconfig.orig $RV_KERNEL_SRC_DIR/arch/riscv/Kconfig
+	fi
 	if [ $err -ne 0 ]; then
 		echo "making kernel Image failed"
 		return $err


### PR DESCRIPTION
AP/TP will not use this configuration.