### PR TITLE
riscv:sophgo:ai: disable tpu-scalar schedule for runtime.

### DIFF
--- a/scripts/disable_sche.c
+++ b/scripts/disable_sche.c
@@ -1,0 +1,80 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/fs.h>
+#include <linux/uaccess.h>
+#include <linux/io.h>
+#include <linux/mm.h>
+#include <linux/slab.h>
+#include <linux/device/class.h>
+#include <linux/device.h>
+#include <asm/csr.h>
+
+#define DEVICE_NAME "disable_sche"
+#define IOCTL_SET_PHYS_ADDR _IOW('p', 1, unsigned long)
+int timer_enter_print;
+static int major;
+static struct class *cls;
+
+static int device_open(struct inode *inode, struct file *file)
+{
+	return 0;
+}
+
+static int device_release(struct inode *inode, struct file *file)
+{
+	return 0;
+}
+
+static long device_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
+{
+	csr_set(CSR_SIE, 0);
+	csr_set(CSR_IP, 0);
+	timer_enter_print = 1;
+	pr_err("disable timer interrupt\n");
+	return 0;
+}
+
+static int device_mmap(struct file *file, struct vm_area_struct *vma)
+{
+	return 0;
+}
+
+static struct file_operations fops = {
+	.owner = THIS_MODULE,
+	.open = device_open,
+	.release = device_release,
+	.unlocked_ioctl = device_ioctl,
+	.mmap = device_mmap,
+};
+
+static int __init disable_sche_init(void)
+{
+	pr_err("init disable scheduler module\n");
+	major = register_chrdev(0, DEVICE_NAME, &fops);
+	if (major < 0) {
+		printk(KERN_ALERT "Failed to register character device\n");
+		return major;
+	}
+
+	cls = class_create(DEVICE_NAME);
+	device_create(cls, NULL, MKDEV(major, 0), NULL, DEVICE_NAME);
+	pr_err("phys_mem device registered with major number %d\n", major);
+
+	return 0;
+}
+
+static void __exit disable_sche_exit(void)
+{
+	device_destroy(cls, MKDEV(major, 0));
+	class_destroy(cls);
+	unregister_chrdev(major, DEVICE_NAME);
+
+	printk(KERN_INFO "phys_mem device unregistered\n");
+}
+
+module_init(disable_sche_init);
+module_exit(disable_sche_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("tingzhu.wang@sophgo.com");
+MODULE_DESCRIPTION("a simple device driver for mapping physical memory to user space");

--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -740,6 +740,11 @@ function build_rv_kernel()
 		cp arch/riscv/Kconfig arch/riscv/Kconfig.orig
 		patch -p1 < $RV_TOP_DIR/bootloader-riscv/scripts/ap_tp_kernel.patch
 	fi
+	if [ "$1" = "tp" ]; then
+		echo "Disable schedule for tp kernel!"
+		cp $RV_TOP_DIR/bootloader-riscv/scripts/disable_sche.c drivers/soc/sophgo/map_memory
+		patch -p1 < $RV_TOP_DIR/bootloader-riscv/scripts/tp_disable_sche.patch
+	fi
 	make O=$RV_KERNEL_BUILD_DIR ARCH=riscv CROSS_COMPILE=$RISCV64_LINUX_CROSS_COMPILE $RV_KERNEL_CONFIG
 	err=$?
 	popd
@@ -757,9 +762,15 @@ function build_rv_kernel()
 	err=$?
 
 	popd
+	pushd $RV_KERNEL_SRC_DIR
 	if [ "$1" = "ap" -o "$1" = "tp" ]; then
 		mv $RV_KERNEL_SRC_DIR/arch/riscv/Kconfig.orig $RV_KERNEL_SRC_DIR/arch/riscv/Kconfig
 	fi
+	if [ "$1" = "tp" ]; then
+		rm -rf drivers/soc/sophgo/map_memory/disable_sche.c
+		patch -R -p1 < $RV_TOP_DIR/bootloader-riscv/scripts/tp_disable_sche.patch
+	fi
+	popd
 	if [ $err -ne 0 ]; then
 		echo "making kernel Image failed"
 		return $err

--- a/scripts/tp_disable_sche.patch
+++ b/scripts/tp_disable_sche.patch
@@ -1,0 +1,28 @@
+diff --git a/arch/riscv/kernel/entry.S b/arch/riscv/kernel/entry.S
+index af483de85dfc..eaaf293499c9 100644
+--- a/arch/riscv/kernel/entry.S
++++ b/arch/riscv/kernel/entry.S
+@@ -262,6 +262,12 @@ SYM_CODE_START_NOALIGN(ret_from_exception)
+ 	REG_L  a2, PT_EPC(sp)
+ 	REG_SC x0, a2, PT_EPC(sp)
+ 
++	la x1, timer_enter_print
++	lw x3, 0(x1)
++	beqz x3, dis_sche
++	andi a0, a0, 0xffffffffffffff00
++	csrw CSR_SIE, zero
++dis_sche:
+ 	csrw CSR_STATUS, a0
+ 	csrw CSR_EPC, a2
+ 
+diff --git a/drivers/soc/sophgo/map_memory/Makefile b/drivers/soc/sophgo/map_memory/Makefile
+index 26c48551c4bc..2008b9394dc5 100644
+--- a/drivers/soc/sophgo/map_memory/Makefile
++++ b/drivers/soc/sophgo/map_memory/Makefile
+@@ -1,2 +1,3 @@
+ 
+-obj-$(CONFIG_SOPHGO_MAP_MEMORY)	+= bm1690_map.o
+\ No newline at end of file
++obj-$(CONFIG_SOPHGO_MAP_MEMORY)	+= bm1690_map.o
++obj-y += disable_sche.o
+\ No newline at end of file


### PR DESCRIPTION
Only use build_rv_kernel tp cmd will disable this.